### PR TITLE
Use `CommonCrypto` instead of the obsolete `OpenSSL` on Apple platforms.

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,6 +1,14 @@
 CC=gcc
 CFLAGS=-static -Wall -g 
-LDFLAGS=-L../src -ldp -lpthread  -lcrypto
+LDFLAGS=-L../src -ldp
+
+ifneq ($(OS),Windows_NT)
+	OS = $(shell uname -s)
+endif
+
+ifneq ($(OS),Darwin)
+	LDFLAGS += -lpthread -lcrypto
+endif
 
 TARGET=demo
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,15 @@
 
 CC=gcc
 CFLAGS=-static -Wall -g 
-LDFLAGS=-lpthread -lcrypto
+LDFLAGS=
+
+ifneq ($(OS),Windows_NT)
+	OS = $(shell uname -s)
+endif
+
+ifneq ($(OS),Darwin)
+	LDFLAGS += -lpthread -lcrypto
+endif
 
 SOURCES=$(wildcard *.c)
 OBJECTS=$(patsubst %.c, %.o, $(SOURCES))

--- a/src/dplus.h
+++ b/src/dplus.h
@@ -55,7 +55,9 @@
 #include <sys/select.h>
 #endif
 
+#ifndef __APPLE__
 #include <openssl/evp.h>
+#endif /* __APPLE__ */
 
 #include "lruhash.h"
 #include "locks.h"

--- a/src/locks.c
+++ b/src/locks.c
@@ -82,6 +82,8 @@ void dp_thread_join(dp_thread_t thr)
 
 #endif
 
+#ifndef __APPLE__
+
 /** global lock list for openssl locks */
 static lock_basic_t *dp_openssl_locks = NULL;
 
@@ -145,3 +147,5 @@ void dp_openssl_lock_delete(void)
     }
     free(dp_openssl_locks);
 }
+
+#endif /* __APPLE__ */

--- a/src/locks.h
+++ b/src/locks.h
@@ -64,8 +64,12 @@ typedef pthread_t dp_thread_t;
 
 #endif
 
+#ifndef __APPLE__
+
 #include <openssl/crypto.h>
 int dp_openssl_lock_init(void);
 void dp_openssl_lock_delete(void);
+
+#endif /* __APPLE__ */
 
 #endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,14 @@
 CC=gcc
 CFLAGS=-static -Wall -g 
-LDFLAGS=-L../src -ldp -lpthread -lcrypto
+LDFLAGS=-L../src -ldp
+
+ifneq ($(OS),Windows_NT)
+	OS = $(shell uname -s)
+endif
+
+ifneq ($(OS),Darwin)
+	LDFLAGS += -lpthread -lcrypto
+endif
 
 SOURCES=$(wildcard *.c)
 OBJECTS=$(patsubst %.c, %.o, $(SOURCES))


### PR DESCRIPTION
For OS X, OpenSSL has been marked for deprecation since OS X 10.7 Lion, and Apple has made it obsolete as of OS X 10.11 El Capitan.
For iOS, tvOS & watchOS, Apple has never made OpenSSL available on these platforms.
